### PR TITLE
Changed a quote in README.md to make Cocoapods happy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The best and fastest way of integrating SPYTestLog is with CocoaPods.  SPYTestLo
 
 ```
 target :YOUR_TEST_TARGET, :exclusive => true do
-  pod 'SPYTestLog’
+  pod 'SPYTestLog'
 end
 ```
 


### PR DESCRIPTION
```
pod 'SPYTestLog’
```

doesn't work, Cocoapods outputs "unterminated string meets end of file".
To make Cocoapods happy, I changed the second quote:

```
pod 'SPYTestLog'
```

Since many people like copy-paste-driven development, it should be more convenient :)

P.S. Thank you for your pod, it's great :)
